### PR TITLE
Move argument parsing to click

### DIFF
--- a/mergekit/io/loader.py
+++ b/mergekit/io/loader.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 import safetensors
 import torch

--- a/mergekit/io/tensor_writer.py
+++ b/mergekit/io/tensor_writer.py
@@ -101,7 +101,7 @@ class TensorWriter:
         ) as file:
             json.dump(
                 {
-                    "metadata": {"mergekit_version": "0.0.3.1"},
+                    "metadata": {"mergekit_version": "0.0.3.2"},
                     "weight_map": self.weight_map,
                 },
                 file,

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -37,7 +37,6 @@ class MergeOptions(BaseModel):
     low_cpu_memory: bool = False
     out_shard_size: int = parse_kmb("5B")
     copy_tokenizer: bool = True
-    allow_crimes: bool = False
     clone_tensors: bool = False
     trust_remote_code: bool = False
     random_seed: Optional[int] = None

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2024 Charles O. Goddard
+#
+# This software is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+import typing
+from typing import Any, Callable, Optional, Union
+
+import click
+from click.core import Context, Parameter
+
+from mergekit.common import parse_kmb
+from mergekit.merge import MergeOptions
+
+OPTION_HELP = {
+    "allow_crimes": "Allow mixing architectures",
+    "transformers_cache": "Override storage path for downloaded models",
+    "lora_merge_cache": "Path to store merged LORA models",
+    "cuda": "Perform matrix arithmetic on GPU",
+    "low_cpu_memory": "Store results and intermediate values on GPU. Useful if VRAM > RAM",
+    "out_shard_size": "Number of parameters per output shard  [default: 5B]",
+    "copy_tokenizer": "Copy a tokenizer to the output",
+    "clone_tensors": "Clone tensors before saving, to allow multiple occurrences of the same layer",
+    "trust_remote_code": "Trust remote code from huggingface repos (danger)",
+    "random_seed": "Seed for reproducible use of randomized merge methods",
+    "lazy_unpickle": "Experimental lazy unpickler for lower memory usage",
+}
+
+
+class ShardSizeParamType(click.ParamType):
+    name = "size"
+
+    def convert(
+        self, value: Any, param: Optional[Parameter], ctx: Optional[Context]
+    ) -> int:
+        return parse_kmb(value)
+
+
+def add_merge_options(f: Callable) -> Callable:
+    def wrapper(*args, **kwargs):
+        arg_dict = {}
+        for field_name in MergeOptions.model_fields:
+            if field_name in kwargs:
+                arg_dict[field_name] = kwargs.pop(field_name)
+
+        kwargs["merge_options"] = MergeOptions(**arg_dict)
+        f(*args, **kwargs)
+
+    for field_name, info in reversed(MergeOptions.model_fields.items()):
+        origin = typing.get_origin(info.annotation)
+        if origin is Union:
+            ty, prob_none = typing.get_args(info.annotation)
+            assert prob_none is type(None)
+            field_type = ty
+        else:
+            field_type = info.annotation
+
+        if field_name == "out_shard_size":
+            field_type = ShardSizeParamType()
+
+        arg_name = field_name.replace("_", "-")
+        if field_type == bool:
+            arg_str = f"--{arg_name}/--no-{arg_name}"
+        else:
+            arg_str = f"--{arg_name}"
+
+        help_str = OPTION_HELP.get(field_name, None)
+        wrapper = click.option(
+            arg_str,
+            type=field_type,
+            default=info.default,
+            help=help_str,
+            show_default=field_name != "out_shard_size",
+        )(wrapper)
+
+    return wrapper

--- a/mergekit/scripts/bakllama.py
+++ b/mergekit/scripts/bakllama.py
@@ -46,6 +46,7 @@ class BakllamaConfig(BaseModel):
 @click.option(
     "--clone-tensors/--no-clone-tensors",
     type=bool,
+    is_flag=True,
     help="Clone tensors before saving, to allow multiple occurrences of the same layer",
     default=False,
 )

--- a/mergekit/scripts/bakllama.py
+++ b/mergekit/scripts/bakllama.py
@@ -15,10 +15,9 @@
 
 from typing import List, Optional
 
-import typer
+import click
 import yaml
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from mergekit.config import (
     ConditionalParameter,
@@ -41,16 +40,21 @@ class BakllamaConfig(BaseModel):
     lm_head_source: Optional[str] = None
 
 
+@click.command("bakllama")
+@click.argument("config_path", type=click.Path(exists=True, dir_okay=False))
+@click.argument("out_path", type=str)
+@click.option(
+    "--clone-tensors/--no-clone-tensors",
+    type=bool,
+    help="Clone tensors before saving, to allow multiple occurrences of the same layer",
+    default=False,
+)
+@click.option("--fp16/--no-fp16", type=bool, default=False)
 def main(
     config_path: str,
     out_path: str,
-    clone_tensors: Annotated[
-        bool,
-        typer.Option(
-            help="Clone tensors before saving, to allow multiple occurrences of the same layer"
-        ),
-    ] = False,
-    fp16: bool = False,
+    clone_tensors: bool,
+    fp16: bool,
 ):
     """Wrapper for using legacy bakllama configuration files."""
     with open(config_path, "r", encoding="utf-8") as file:
@@ -75,9 +79,5 @@ def main(
     run_merge(merge_config, out_path, MergeOptions(clone_tensors=clone_tensors))
 
 
-def _main():
-    typer.run(main)
-
-
 if __name__ == "__main__":
-    _main()
+    main()

--- a/mergekit/scripts/layershuffle.py
+++ b/mergekit/scripts/layershuffle.py
@@ -14,11 +14,10 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 import random
-from typing import List, Optional
+from typing import List
 
-import typer
+import click
 import yaml
-from typing_extensions import Annotated
 
 from mergekit.architecture import get_architecture_info
 from mergekit.common import ModelReference
@@ -28,49 +27,51 @@ from mergekit.config import (
     OutputSliceDefinition,
 )
 from mergekit.merge import MergeOptions, run_merge
+from mergekit.options import add_merge_options
 
 
+@click.command()
+@click.argument("out_path", type=str)
+@click.option("--model", "-m", multiple=True, type=str, help="Add a model to the merge")
+@click.option(
+    "--weight",
+    "-w",
+    multiple=True,
+    type=float,
+    default=[],
+    show_default=False,
+    help="Weighting for a model",
+)
+@click.option(
+    "--print-yaml/--no-print-yaml",
+    is_flag=True,
+    help="Print YAML merge config for resulting model",
+)
+@click.option(
+    "--write-yaml",
+    type=click.Path(writable=True),
+    help="Path to write YAML merge config to",
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Generate a config but do not run the merge"
+)
+@click.option("--fp16/--no-fp16", is_flag=True, help="Use FP16 precision")
+@click.option(
+    "--full-random/--no-full-random",
+    is_flag=True,
+    help="Randomize layer index as well as source model",
+)
+@add_merge_options
 def main(
-    out_path: Annotated[
-        str, typer.Argument(help="Output path for merged model", metavar="PATH")
-    ],
-    model: Annotated[
-        List[str], typer.Option(help="Add a model to the merge", metavar="MODEL")
-    ],
-    weight: Annotated[
-        List[float],
-        typer.Option(
-            help="Weighting for a model",
-            default_factory=list,
-            show_default=False,
-        ),
-    ],
-    print_yaml: Annotated[
-        bool, typer.Option(help="Print YAML merge config for resulting model")
-    ] = False,
-    write_yaml: Annotated[
-        Optional[str], typer.Option(help="Path to write YAML merge config to")
-    ] = None,
-    dry_run: Annotated[
-        bool, typer.Option(help="Generate a config but do not run the merge")
-    ] = False,
-    fp16: bool = False,
-    lora_merge_cache: Annotated[
-        Optional[str],
-        typer.Option(help="Path to store merged LORA models", metavar="PATH"),
-    ] = None,
-    transformers_cache: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Override storage path for downloaded models", metavar="PATH"
-        ),
-    ] = None,
-    copy_tokenizer: Annotated[
-        bool, typer.Option(help="Copy a tokenizer to the output")
-    ] = True,
-    full_random: Annotated[
-        bool, typer.Option(help="Randomize layer index as well as source model")
-    ] = False,
+    out_path: str,
+    model: List[str],
+    weight: List[float],
+    print_yaml: bool,
+    write_yaml: bool,
+    dry_run: bool,
+    fp16: bool,
+    full_random: bool,
+    merge_options: MergeOptions,
 ):
     models = [ModelReference.parse(m) for m in model]
 
@@ -135,17 +136,9 @@ def main(
     run_merge(
         merge_config,
         out_path,
-        MergeOptions(
-            lora_merge_cache=lora_merge_cache,
-            transformers_cache=transformers_cache,
-            copy_tokenizer=copy_tokenizer,
-        ),
+        options=merge_options,
     )
 
 
-def _main():
-    typer.run(main)
-
-
 if __name__ == "__main__":
-    _main()
+    main()

--- a/mergekit/scripts/layershuffle.py
+++ b/mergekit/scripts/layershuffle.py
@@ -30,7 +30,7 @@ from mergekit.merge import MergeOptions, run_merge
 from mergekit.options import add_merge_options
 
 
-@click.command()
+@click.command("mergekit-layershuffle")
 @click.argument("out_path", type=str)
 @click.option("--model", "-m", multiple=True, type=str, help="Add a model to the merge")
 @click.option(

--- a/mergekit/scripts/legacy.py
+++ b/mergekit/scripts/legacy.py
@@ -23,7 +23,7 @@ from mergekit.merge import MergeOptions, run_merge
 from mergekit.options import add_merge_options
 
 
-@click.command()
+@click.command("mergekit-legacy")
 @click.argument("out_path", type=str)
 @click.option(
     "--merge", "merge", type=str, multiple=True, help="Add a model to the merge"

--- a/mergekit/scripts/legacy.py
+++ b/mergekit/scripts/legacy.py
@@ -15,68 +15,81 @@
 
 from typing import List, Optional
 
-import typer
+import click
 import yaml
-from typing_extensions import Annotated
 
 from mergekit.config import InputModelDefinition, MergeConfiguration
 from mergekit.merge import MergeOptions, run_merge
+from mergekit.options import add_merge_options
 
 
+@click.command()
+@click.argument("out_path", type=str)
+@click.option(
+    "--merge", "merge", type=str, multiple=True, help="Add a model to the merge"
+)
+@click.option(
+    "--density",
+    "density",
+    type=float,
+    multiple=True,
+    default=[],
+    help="Fraction of weights to keep for each model (ties only)",
+)
+@click.option(
+    "--weight",
+    "weight",
+    type=float,
+    multiple=True,
+    default=[],
+    help="Weighting for a model (default 1.0 for all models if not specified)",
+)
+@click.option(
+    "--method", "method", type=str, default="ties", help="Method used to merge models"
+)
+@click.option(
+    "--base-model", "base_model", type=str, default=None, help="Base model for merge"
+)
+@click.option(
+    "--normalize/--no-normalize",
+    "normalize",
+    is_flag=True,
+    default=True,
+    help="Divide merged parameters by the sum of weights",
+)
+@click.option(
+    "--int8-mask/--no-int8-mask",
+    "int8_mask",
+    is_flag=True,
+    help="Store intermediate masks in int8 to save memory",
+)
+@click.option("--bf16/--no-bf16", "bf16", is_flag=True, help="Use bfloat16")
+@click.option(
+    "--naive-count/--no-naive-count",
+    "naive_count",
+    is_flag=True,
+    help="Use naive sign count instead of weight (ties only)",
+)
+@click.option(
+    "--print-yaml/--no-print-yaml",
+    "print_yaml",
+    is_flag=True,
+    help="Print generated YAML configuration",
+)
+@add_merge_options
 def main(
-    out_path: Annotated[str, typer.Argument(help="Output directory for final model")],
-    merge: Annotated[
-        List[str], typer.Option(help="Add a model to the merge", metavar="MODEL")
-    ],
-    density: Annotated[
-        List[float],
-        typer.Option(
-            help="Fraction of weights to keep for each model (ties only)",
-            default_factory=list,
-            show_default=False,
-        ),
-    ],
-    weight: Annotated[
-        List[float],
-        typer.Option(
-            help="Weighting for a model (default 1.0 for all models if not specified)",
-            default_factory=list,
-            show_default=False,
-        ),
-    ],
-    method: Annotated[str, typer.Option(help="Method used to merge models")] = "ties",
-    base_model: Annotated[
-        Optional[str], typer.Option(help="Base model for merge")
-    ] = None,
-    normalize: Annotated[
-        bool,
-        typer.Option(
-            help="Divide merged parameters by the sum of weights",
-        ),
-    ] = True,
-    merged_cache_dir: Annotated[
-        Optional[str], typer.Option(help="Storage path for merged LoRA models")
-    ] = None,
-    cache_dir: Annotated[
-        Optional[str], typer.Option(help="Override storage path for downloaded models")
-    ] = None,
-    cuda: bool = False,
-    int8_mask: Annotated[
-        bool, typer.Option(help="Store intermediate masks in int8 to save memory")
-    ] = False,
-    bf16: Annotated[bool, typer.Option(help="Use bfloat16")] = True,
-    naive_count: Annotated[
-        bool, typer.Option(help="Use naive sign count instead of weight (ties only)")
-    ] = False,
-    copy_tokenizer: Annotated[
-        bool, typer.Option(help="Copy base model tokenizer into output")
-    ] = True,
-    print_yaml: Annotated[
-        bool, typer.Option(help="Print generated YAML configuration")
-    ] = False,
-    allow_crimes: Annotated[
-        bool, typer.Option(help="Allow mixing architectures")
-    ] = False,
+    out_path: str,
+    merge: List[str],
+    density: List[float],
+    weight: List[float],
+    method: str,
+    base_model: Optional[str],
+    normalize: bool,
+    int8_mask: bool,
+    bf16: bool,
+    naive_count: bool,
+    print_yaml: bool,
+    merge_options: MergeOptions,
 ):
     """Wrapper for using a subset of legacy-style script arguments."""
     models = [InputModelDefinition(model=model, parameters={}) for model in merge]
@@ -121,19 +134,9 @@ def main(
     run_merge(
         merge_config,
         out_path,
-        options=MergeOptions(
-            lora_merge_cache=merged_cache_dir,
-            transformers_cache=cache_dir,
-            cuda=cuda,
-            copy_tokenizer=copy_tokenizer,
-            allow_crimes=allow_crimes,
-        ),
+        options=merge_options,
     )
 
 
-def _main():
-    typer.run(main)
-
-
 if __name__ == "__main__":
-    _main()
+    main()

--- a/mergekit/scripts/run_yaml.py
+++ b/mergekit/scripts/run_yaml.py
@@ -14,67 +14,25 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 import logging
-from typing import Optional
 
-import typer
+import click
 import yaml
-from typing_extensions import Annotated
 
-from mergekit.common import parse_kmb
 from mergekit.config import MergeConfiguration
 from mergekit.merge import MergeOptions, run_merge
+from mergekit.options import add_merge_options
 
 
+@click.command("mergekit-yaml")
+@click.argument("config_file")  # , help="YAML configuration file")
+@click.argument("out_path")  # , help="Path to write result model")
+@click.option("--verbose", "-v", type=bool, default=False, help="Verbose logging")
+@add_merge_options
 def main(
-    config_file: Annotated[str, typer.Argument(help="YAML configuration file")],
-    out_path: Annotated[str, typer.Argument(help="Path to write result model")],
-    lora_merge_cache: Annotated[
-        Optional[str],
-        typer.Option(help="Path to store merged LORA models", metavar="PATH"),
-    ] = None,
-    transformers_cache: Annotated[
-        Optional[str],
-        typer.Option(
-            help="Override storage path for downloaded models", metavar="PATH"
-        ),
-    ] = None,
-    cuda: Annotated[
-        bool, typer.Option(help="Perform matrix arithmetic on GPU")
-    ] = False,
-    low_cpu_memory: Annotated[
-        bool,
-        typer.Option(
-            help="Store results and intermediate values on GPU. Useful if VRAM > RAM"
-        ),
-    ] = False,
-    copy_tokenizer: Annotated[
-        bool, typer.Option(help="Copy a tokenizer to the output")
-    ] = True,
-    allow_crimes: Annotated[
-        bool, typer.Option(help="Allow mixing architectures")
-    ] = False,
-    out_shard_size: Annotated[
-        Optional[int],
-        typer.Option(
-            help="Number of parameters per output shard  [default: 5B]",
-            parser=parse_kmb,
-            show_default=False,
-            metavar="NUM",
-        ),
-    ] = parse_kmb("5B"),
-    verbose: Annotated[bool, typer.Option("-v", help="Verbose logging")] = False,
-    trust_remote_code: Annotated[
-        bool, typer.Option(help="Trust remote code when merging LoRAs")
-    ] = False,
-    clone_tensors: Annotated[
-        bool,
-        typer.Option(
-            help="Clone tensors before saving, to allow multiple occurrences of the same layer"
-        ),
-    ] = False,
-    lazy_unpickle: Annotated[
-        bool, typer.Option(help="Experimental lazy unpickler for lower memory usage")
-    ] = False,
+    merge_options: MergeOptions,
+    config_file: str,
+    out_path: str,
+    verbose: bool,
 ):
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
 
@@ -85,25 +43,9 @@ def main(
     run_merge(
         merge_config,
         out_path,
-        options=MergeOptions(
-            lora_merge_cache=lora_merge_cache,
-            transformers_cache=transformers_cache,
-            cuda=cuda,
-            low_cpu_memory=low_cpu_memory,
-            copy_tokenizer=copy_tokenizer,
-            allow_crimes=allow_crimes,
-            out_shard_size=out_shard_size,
-            trust_remote_code=trust_remote_code,
-            clone_tensors=clone_tensors,
-            lazy_unpickle=lazy_unpickle,
-        ),
+        options=merge_options,
     )
 
 
-def _main():
-    # just a wee li'l stub for setuptools
-    typer.run(main)
-
-
 if __name__ == "__main__":
-    _main()
+    main()

--- a/mergekit/scripts/run_yaml.py
+++ b/mergekit/scripts/run_yaml.py
@@ -24,9 +24,11 @@ from mergekit.options import add_merge_options
 
 
 @click.command("mergekit-yaml")
-@click.argument("config_file")  # , help="YAML configuration file")
-@click.argument("out_path")  # , help="Path to write result model")
-@click.option("--verbose", "-v", type=bool, default=False, help="Verbose logging")
+@click.argument("config_file")
+@click.argument("out_path")
+@click.option(
+    "--verbose", "-v", type=bool, default=False, is_flag=True, help="Verbose logging"
+)
 @add_merge_options
 def main(
     merge_options: MergeOptions,

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -16,7 +16,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "84cRJT6_ecbw"
       },
@@ -40,17 +40,26 @@
       "source": [
         "# actually do merge\n",
         "import torch\n",
-        "import mergekit.scripts.run_yaml\n",
+        "import yaml\n",
         "\n",
-        "mergekit.scripts.run_yaml.main(\n",
-        "    CONFIG_YML,\n",
-        "    OUTPUT_PATH,\n",
-        "    LORA_MERGE_CACHE,\n",
-        "    cuda=torch.cuda.is_available(),\n",
-        "    copy_tokenizer=COPY_TOKENIZER,\n",
-        "    lazy_unpickle=LAZY_UNPICKLE,\n",
-        "    low_cpu_memory=LOW_CPU_MEMORY,\n",
-        ")"
+        "from mergekit.config import MergeConfiguration\n",
+        "from mergekit.merge import MergeOptions, run_merge\n",
+        "\n",
+        "with open(CONFIG_YML, \"r\", encoding=\"utf-8\") as fp:\n",
+        "    merge_config = MergeConfiguration.model_validate(yaml.safe_load(fp))\n",
+        "\n",
+        "run_merge(\n",
+        "    merge_config,\n",
+        "    out_path=OUTPUT_PATH,\n",
+        "    options=MergeOptions(\n",
+        "        lora_merge_cache=LORA_MERGE_CACHE,\n",
+        "        cuda=torch.cuda.is_available(),\n",
+        "        copy_tokenizer=COPY_TOKENIZER,\n",
+        "        lazy_unpickle=LAZY_UNPICKLE,\n",
+        "        low_cpu_memory=LOW_CPU_MEMORY,\n",
+        "    ),\n",
+        ")\n",
+        "print(\"Done!\")"
       ]
     }
   ],
@@ -65,7 +74,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.13"
     }
   },
   "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,16 @@ build-backend = "setuptools.build_meta"
 name = "mergekit"
 description = "Tools for merging pre-trained large language models"
 readme = "README.md"
-license = {text = "LGPL-3.0-or-later"}
-version = "0.0.3.1"
-authors = [
-    {name = "Charles Goddard", email = "chargoddard@gmail.com"},
-]
+license = { text = "LGPL-3.0-or-later" }
+version = "0.0.3.2"
+authors = [{ name = "Charles Goddard", email = "chargoddard@gmail.com" }]
 dependencies = [
     "torch>=2.0.0",
     "tqdm==4.66.1",
-    "typer==0.9.0",
-    "safetensors==0.3.3",
-    "accelerate==0.23.0",
-    "pydantic==2.4.0",
+    "click==8.1.7",
+    "safetensors==0.4.1",
+    "accelerate==0.25.0",
+    "pydantic==2.5.3",
     "transformers",
     "huggingface_hub",
     "peft",
@@ -27,21 +25,17 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "black~=23.11.0",
-    "isort~=5.12.0",
-    "pre-commit~=3.5.0",
-]
+dev = ["black~=23.11.0", "isort~=5.12.0", "pre-commit~=3.5.0"]
 
 [project.urls]
 repository = "https://github.com/cg123/mergekit"
 
 
 [project.scripts]
-mergekit-yaml = "mergekit.scripts.run_yaml:_main"
-mergekit-legacy = "mergekit.scripts.legacy:_main"
-mergekit-layershuffle = "mergekit.scripts.layershuffle:_main"
-bakllama = "mergekit.scripts.bakllama:_main"
+mergekit-yaml = "mergekit.scripts.run_yaml:main"
+mergekit-legacy = "mergekit.scripts.legacy:main"
+mergekit-layershuffle = "mergekit.scripts.layershuffle:main"
+bakllama = "mergekit.scripts.bakllama:main"
 
 [tool.setuptools]
 packages = ["mergekit"]


### PR DESCRIPTION
There are too many scripts with common arguments, and Typer isn't presenting a great way to unify them. Move to click for argument parsing instead.