### PR TITLE
Fix fp16 DARE on CPU

### DIFF
--- a/tests/test_sparsify.py
+++ b/tests/test_sparsify.py
@@ -49,3 +49,11 @@ class TestBernoulli:
             sample_tensor, density=0.5, method=SparsificationMethod.random
         )
         assert 0 < torch.count_nonzero(result) <= sample_tensor.view(-1).shape[0]
+
+    def test_cpu_dtypes(self, sample_tensor):
+        for dt in (torch.float16, torch.bfloat16, torch.float32):
+            sparsify(
+                tensor=sample_tensor.to(dtype=dt).cpu(),
+                density=0.5,
+                method=SparsificationMethod.rescaled_random,
+            )


### PR DESCRIPTION
Use either float32 or bfloat16 for `torch.bernoulli`.

Also improves merge tests by checking for NaN in output tensors.