### PR TITLE
mergekit-mega: compound merging using multiple yaml documents in a single merge config

### DIFF
--- a/examples/mega.yml
+++ b/examples/mega.yml
@@ -14,10 +14,10 @@ parameters:
       value: [1, 0.5, 0.7, 0.3, 0]
     - value: 0.5 # fallback for rest of tensors
 dtype: float16
-out_path: ./models/gradient-slerp
+name: gradient-slerp
 ---
 models:
-  - model: ./models/gradient-slerp
+  - model: gradient-slerp
     parameters:
       density: [1, 0.7, 0.1] # density gradient
       weight: 1.0
@@ -34,4 +34,4 @@ parameters:
   normalize: true
   int8_mask: true
 dtype: float16
-out_path: ./models/gradient-slerp-ties
+name: gradient-slerp-ties

--- a/examples/mega.yml
+++ b/examples/mega.yml
@@ -1,0 +1,37 @@
+slices:
+  - sources:
+      - model: psmathur/orca_mini_v3_13b
+        layer_range: [0, 40]
+      - model: garage-bAInd/Platypus2-13B
+        layer_range: [0, 40]
+merge_method: slerp
+base_model: psmathur/orca_mini_v3_13b
+parameters:
+  t:
+    - filter: self_attn
+      value: [0, 0.5, 0.3, 0.7, 1]
+    - filter: mlp
+      value: [1, 0.5, 0.7, 0.3, 0]
+    - value: 0.5 # fallback for rest of tensors
+dtype: float16
+out_path: ./models/gradient-slerp
+---
+models:
+  - model: ./models/gradient-slerp
+    parameters:
+      density: [1, 0.7, 0.1] # density gradient
+      weight: 1.0
+  - model: WizardLM/WizardMath-13B-V1.0
+    parameters:
+      density: 0.33
+      weight:
+        - filter: mlp
+          value: 0.5
+        - value: 0
+merge_method: ties
+base_model: TheBloke/Llama-2-13B-fp16
+parameters:
+  normalize: true
+  int8_mask: true
+dtype: float16
+out_path: ./models/gradient-slerp-ties

--- a/mergekit/scripts/megamerge.py
+++ b/mergekit/scripts/megamerge.py
@@ -6,13 +6,12 @@ import re
 import click
 import logging
 import os
+from pathlib import Path
 
 from mergekit.merge import MergeOptions, run_merge
 from mergekit.config import MergeConfiguration
 from mergekit.options import add_merge_options
 
-# Regex that matches huggingface path
-hf_path = r"^[a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+(?:\+.+)$"
 merges = {}
 
 def has_circular_dependency(nodes):
@@ -40,31 +39,33 @@ def has_circular_dependency(nodes):
 
     return None 
 
-def merge(m, options, force):
-    # check if out_path exists
-    if not force and os.path.exists(m):
-        logging.info(f"Skipping {m} as it already exists")
-        del merges[m]
-        return
-    elif force and os.path.exists(m):
-        logging.info(f"Overwriting {m} as --force was specified")
+def merge(m, merge_options, force, out_path):
+    # check if output_path exists
+    if os.path.exists(out_path / m):
+        if not force:
+            logging.info(f"Skipping {m} as it already exists")
+            del merges[m]
+            return
+        else:
+            logging.info(f"Overwriting {m} as --force was specified")
 
     if len(merges[m]["deps"]) != 0:
         for dep in merges[m]["deps"]:
             if dep in merges:
-                merge(dep, options, force)
+                merge(dep, merge_options, force, out_path)
 
     logging.info(f"Merging model {m}")
     merge_config: MergeConfiguration = MergeConfiguration.model_validate(merges[m])
     run_merge(
         merge_config,
-        merges[m]["out_path"],
-        options=options,
+        str(out_path / merges[m]["name"]),
+        options=merge_options,
     )
     del merges[m]
 
 @click.command("mergekit-mega")
 @click.argument("config_file")
+@click.argument("out_path")
 @click.option(
     "--verbose", "-v", type=bool, default=False, is_flag=True, help="Verbose logging"
 )
@@ -75,30 +76,46 @@ def merge(m, options, force):
 def main(
     merge_options: MergeOptions,
     config_file: str,
+    out_path: str,
     force: bool,
     verbose: bool,
 ):
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
 
+    out_path = Path(out_path)
     with open(config_file, "r") as f:
         data = yaml.load_all(f, Loader=yaml.FullLoader)
 
         for d in data:
-            merges[d["out_path"]] = d
-            merges[d["out_path"]]["deps"] = []
+            merges[d["name"]] = d
+            merges[d["name"]]["deps"] = []
             if "slices" in d:
                 for slc in d["slices"]:
                     for src in slc["sources"]:
                         if "model" in src and src["model"] is not None:
-                            # if the model is a huggingface model, skip it
-                            if not re.match(hf_path, src["model"]):
-                                merges[d["out_path"]]["deps"].append(src["model"])
+                            model_lora = src["model"].split("+")
+                            # name must not have a slash to avoid path traversal
+                            # therefore, we can use it to check if its a merge from the config
+                            if "/" not in model_lora[0]:
+                                # avoid duplicate deps
+                                if model_lora[0] not in merges[d["name"]]["deps"]:
+                                    merges[d["name"]]["deps"].append(model_lora[0])
+                                src["model"] = str(out_path / model_lora[0])
+                                if len(model_lora) == 2:
+                                    src["model"] += "+" + model_lora[1]
             if "models" in d:
                 for mdl in d["models"]:
                     if "model" in mdl and mdl["model"] is not None:
-                        # if the model is a huggingface model, skip it
-                        if not re.match(hf_path, mdl["model"]):
-                            merges[d["out_path"]]["deps"].append(mdl["model"])
+                        model_lora = mdl["model"].split("+")
+                        # name must not have a slash to avoid path traversal
+                        # therefore, we can use it to check if its a merge from the config
+                        if "/" not in model_lora[0]:
+                            # avoid duplicate deps
+                            if model_lora[0] not in merges[d["name"]]["deps"]:
+                                merges[d["name"]]["deps"].append(model_lora[0])
+                            mdl["model"] = str(out_path / model_lora[0])
+                            if len(model_lora) == 2:
+                                mdl["model"] += "+" + model_lora[1]
 
     logging.info("Merging: " + ', '.join(merges))
 

--- a/mergekit/scripts/megamerge.py
+++ b/mergekit/scripts/megamerge.py
@@ -83,8 +83,6 @@ def main(
     with open(config_file, "r") as f:
         data = yaml.load_all(f, Loader=yaml.FullLoader)
 
-        # find leaf merges, the ones that don't have a local path specified in slices[].sources[].model or models[].model
-        leaf_merges = []
         for d in data:
             merges[d["out_path"]] = d
             merges[d["out_path"]]["deps"] = []

--- a/mergekit/scripts/megamerge.py
+++ b/mergekit/scripts/megamerge.py
@@ -14,6 +14,7 @@ from mergekit.options import add_merge_options
 
 merges = {}
 
+
 def has_circular_dependency(nodes):
     def dfs(node, visited, stack):
         visited[node] = True
@@ -37,7 +38,8 @@ def has_circular_dependency(nodes):
             if dfs(node, visited, stack):
                 return node
 
-    return None 
+    return None
+
 
 def merge(m, merge_options, force, out_path):
     # check if output_path exists
@@ -63,6 +65,7 @@ def merge(m, merge_options, force, out_path):
     )
     del merges[m]
 
+
 @click.command("mergekit-mega")
 @click.argument("config_file")
 @click.argument("out_path")
@@ -70,7 +73,12 @@ def merge(m, merge_options, force, out_path):
     "--verbose", "-v", type=bool, default=False, is_flag=True, help="Verbose logging"
 )
 @click.option(
-    "--force", "-f", type=bool, default=False, is_flag=True, help="overwrite existing merge results instead of skipping them"
+    "--force",
+    "-f",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="overwrite existing merge results instead of skipping them",
 )
 @add_merge_options
 def main(
@@ -120,7 +128,7 @@ def main(
                             if len(model_lora) == 2:
                                 mdl["model"] += "+" + model_lora[1]
 
-    logging.info("Merging: " + ', '.join(merges))
+    logging.info("Merging: " + ", ".join(merges))
 
     if (dep := has_circular_dependency(merges)) is not None:
         logging.error(f"Circular dependency detected: {dep}")
@@ -129,6 +137,7 @@ def main(
     while len(merges) != 0:
         m = list(merges.keys())[0]
         merge(m, merge_options, force)
+
 
 if __name__ == "__main__":
     main()

--- a/mergekit/scripts/megamerge.py
+++ b/mergekit/scripts/megamerge.py
@@ -87,6 +87,9 @@ def main(
         data = yaml.load_all(f, Loader=yaml.FullLoader)
 
         for d in data:
+            if "/" in d["name"]:
+                logging.error("name must not contain a slash")
+                exit(1)
             merges[d["name"]] = d
             merges[d["name"]]["deps"] = []
             if "slices" in d:

--- a/mergekit/scripts/megamerge.py
+++ b/mergekit/scripts/megamerge.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import yaml
+import os
+import re
+from typing import Optional
+from typing_extensions import Annotated
+import typer
+import logging
+import os
+
+from mergekit.merge import MergeOptions, run_merge
+from mergekit.common import parse_kmb
+from mergekit.config import MergeConfiguration
+
+# Regex that matches huggingface path
+hf_path = r"^[a-zA-Z0-9\-]+/[a-zA-Z0-9\-\._]+(?:\+.+)$"
+merges = {}
+
+def merge(m, options):
+    # check if out_path exists
+    if os.path.exists(m):
+        print(f"Skipping {m} as it already exists")
+        del merges[m]
+        return
+
+    if len(merges[m]["deps"]) != 0:
+        for dep in merges[m]["deps"]:
+            if dep in merges:
+                merge(dep, options)
+    print(f"Merging {m}")
+    merge_config: MergeConfiguration = MergeConfiguration.model_validate(merges[m])
+    run_merge(
+        merge_config,
+        merges[m]["out_path"],
+        options=options,
+    )
+    del merges[m]
+
+def main(
+    config_file: Annotated[str, typer.Argument(help="YAML configuration file")],
+    lora_merge_cache: Annotated[
+        Optional[str],
+        typer.Option(help="Path to store merged LORA models", metavar="PATH"),
+    ] = None,
+    transformers_cache: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Override storage path for downloaded models", metavar="PATH"
+        ),
+    ] = None,
+    cuda: Annotated[
+        bool, typer.Option(help="Perform matrix arithmetic on GPU")
+    ] = False,
+    low_cpu_memory: Annotated[
+        bool,
+        typer.Option(
+            help="Store results and intermediate values on GPU. Useful if VRAM > RAM"
+        ),
+    ] = False,
+    copy_tokenizer: Annotated[
+        bool, typer.Option(help="Copy a tokenizer to the output")
+    ] = True,
+    allow_crimes: Annotated[
+        bool, typer.Option(help="Allow mixing architectures")
+    ] = False,
+    out_shard_size: Annotated[
+        Optional[int],
+        typer.Option(
+            help="Number of parameters per output shard  [default: 5B]",
+            parser=parse_kmb,
+            show_default=False,
+            metavar="NUM",
+        ),
+    ] = parse_kmb("5B"),
+    verbose: Annotated[bool, typer.Option("-v", help="Verbose logging")] = False,
+    trust_remote_code: Annotated[
+        bool, typer.Option(help="Trust remote code when merging LoRAs")
+    ] = False,
+    clone_tensors: Annotated[
+        bool,
+        typer.Option(
+            help="Clone tensors before saving, to allow multiple occurrences of the same layer"
+        ),
+    ] = False,
+    lazy_unpickle: Annotated[
+        bool, typer.Option(help="Experimental lazy unpickler for lower memory usage")
+    ] = False,
+):
+    logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
+
+    with open(config_file, "r") as f:
+        data = yaml.load_all(f, Loader=yaml.FullLoader)
+
+        # find leaf merges, the ones that don't have a local path specified in slices[].sources[].model or models[].model
+        leaf_merges = []
+        for d in data:
+            merges[d["out_path"]] = d
+            merges[d["out_path"]]["deps"] = []
+            if "slices" in d:
+                for slc in d["slices"]:
+                    for src in slc["sources"]:
+                        if "model" in src and src["model"] is not None:
+                            # if the model is a huggingface model, skip it
+                            if not re.match(hf_path, src["model"]):
+                                merges[d["out_path"]]["deps"].append(src["model"])
+            if "models" in d:
+                for mdl in d["models"]:
+                    if "model" in mdl and mdl["model"] is not None:
+                        # if the model is a huggingface model, skip it
+                        if not re.match(hf_path, mdl["model"]):
+                            merges[d["out_path"]]["deps"].append(mdl["model"])
+
+    options = MergeOptions(
+            lora_merge_cache=lora_merge_cache,
+            transformers_cache=transformers_cache,
+            cuda=cuda,
+            low_cpu_memory=low_cpu_memory,
+            copy_tokenizer=copy_tokenizer,
+            allow_crimes=allow_crimes,
+            out_shard_size=out_shard_size,
+            trust_remote_code=trust_remote_code,
+            clone_tensors=clone_tensors,
+            lazy_unpickle=lazy_unpickle,
+    )
+
+    print("Merging:\n" + '\n'.join(merges))
+
+    while len(merges) != 0:
+        m = list(merges.keys())[0]
+        merge(m, options)
+
+
+
+def _main():
+    # just a wee li'l stub for setuptools
+    typer.run(main)
+
+
+if __name__ == "__main__":
+    _main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ repository = "https://github.com/cg123/mergekit"
 
 
 [project.scripts]
-mergekit-yaml = "mergekit.scripts.run_yaml:_main"
-mergekit-mega = "mergekit.scripts.megamerge:_main"
-mergekit-legacy = "mergekit.scripts.legacy:_main"
-mergekit-layershuffle = "mergekit.scripts.layershuffle:_main"
-bakllama = "mergekit.scripts.bakllama:_main"
+mergekit-yaml = "mergekit.scripts.run_yaml:main"
+mergekit-mega = "mergekit.scripts.megamerge:main"
+mergekit-legacy = "mergekit.scripts.legacy:main"
+mergekit-layershuffle = "mergekit.scripts.layershuffle:main"
+bakllama = "mergekit.scripts.bakllama:main"
 
 [tool.setuptools]
 packages = ["mergekit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ repository = "https://github.com/cg123/mergekit"
 
 
 [project.scripts]
-mergekit-yaml = "mergekit.scripts.run_yaml:main"
-mergekit-legacy = "mergekit.scripts.legacy:main"
-mergekit-layershuffle = "mergekit.scripts.layershuffle:main"
-bakllama = "mergekit.scripts.bakllama:main"
+mergekit-yaml = "mergekit.scripts.run_yaml:_main"
+mergekit-mega = "mergekit.scripts.megamerge:_main"
+mergekit-legacy = "mergekit.scripts.legacy:_main"
+mergekit-layershuffle = "mergekit.scripts.layershuffle:_main"
+bakllama = "mergekit.scripts.bakllama:_main"
 
 [tool.setuptools]
 packages = ["mergekit"]


### PR DESCRIPTION
This adds the a new script `mergekit-mega` that takes a yaml file with multiple merge configs specified as individual yaml documents and merges them in the proper order depending on interdependencies.

A couple of quirks that should probably be ironed out before merging
1. ~~Currently there's no special handling for circular dependencies, and I'm unsure how it would break.~~
2. ~~I dont know if the `out_path` in the yaml file is ideal, or if it should instead be a `name`, and the out_dir gets specified on the command line.~~
3. ~~The huggingface repo regex probably doesn't cover all the edge cases in its current form~~
4. Unsure if just skipping over existing output directories should be the default behavior or if it should just abort, and have --force and --skip be 2 flags.