### PR TITLE
Tokenizer merge fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-added-large-files
       - id: check-yaml
+        args: ["--allow-multiple-documents"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/mergekit/io/loader.py
+++ b/mergekit/io/loader.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence
 
 import safetensors
 import torch

--- a/mergekit/merge_methods/tokenizer_permute.py
+++ b/mergekit/merge_methods/tokenizer_permute.py
@@ -28,7 +28,7 @@ class TokenizerPermutationMerge(MergeMethod):
     def __call__(
         self,
         input_tensors: Dict[TensorReference, torch.Tensor],
-        embed_permutations: Dict[ModelReference, torch.IntTensor],
+        embed_permutations: Dict[ModelReference, Dict[int, int]],
         config: ConfigReader,
         **_kwargs,
     ) -> torch.Tensor:
@@ -47,15 +47,20 @@ class TokenizerPermutationMerge(MergeMethod):
             models.append(tr.model)
 
             x = input_tensors[tr]
-            p = embed_permutations[tr.model].to(dtype=x.dtype, device=x.device)
-            temp_dtype = torch.float32 if x.device.type == "cpu" else x.dtype
-            if p.shape[1] == x.shape[0]:
-                xp = (p.to(dtype=temp_dtype) @ x.to(dtype=temp_dtype)).to(x.dtype)
-            else:
-                raise RuntimeError("Shape mismatch")
+            p = embed_permutations[tr.model]
+
+            xp = torch.zeros((len(p), x.shape[-1]), dtype=x.dtype, device=x.device)
+            mask = torch.zeros((len(p),), dtype=torch.bool, device=x.device)
+            for out_idx in p:
+                in_idx = p[out_idx]
+                if in_idx < 0:
+                    continue
+
+                xp[out_idx, :] = x[in_idx, :]
+                mask[out_idx] = 1
 
             expanded.append(xp)
-            masks.append(p.sum(dim=-1, keepdim=True) > 0)
+            masks.append(mask)
 
             is_base = tr.model == config.base_model
             if use_slerp:
@@ -63,11 +68,10 @@ class TokenizerPermutationMerge(MergeMethod):
                 weight = (1.0 - t) if is_base else t
             else:
                 weight = config.parameter("weight", model=tr.model, default=1.0)
-
             weights.append(weight)
 
         expanded = torch.stack(expanded, dim=0)
-        masks = torch.stack(masks, dim=0)
+        masks = torch.stack(masks, dim=0).unsqueeze(-1)
         weights = (
             torch.tensor(weights, dtype=expanded.dtype, device=expanded.device)
             .unsqueeze(-1)

--- a/mergekit/tokenizer.py
+++ b/mergekit/tokenizer.py
@@ -1,6 +1,9 @@
+import json
 import logging
 from typing import Dict, Optional, Tuple
 
+import tokenizers
+import tokenizers.models
 import torch
 import tqdm
 import transformers
@@ -21,6 +24,103 @@ def get_vocab_size(model_path: str, trust_remote_code: bool) -> Optional[int]:
     return None
 
 
+def get_stripped_tokenizer(
+    path: str, trust_remote_code: bool = False
+) -> transformers.PreTrainedTokenizerFast:
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        path, trust_remote_code=trust_remote_code, use_fast=True
+    )
+    vocab_size = get_vocab_size(path) or len(tokenizer.get_vocab())
+
+    unused_toks = [
+        tok for tok, idx in tokenizer.get_vocab().items() if idx >= vocab_size
+    ]
+    if not unused_toks:
+        return tokenizer
+
+    if not tokenizer.is_fast:
+        raise RuntimeError(
+            f"Model {path} has unused tokens and does not support fast "
+            "tokenizer - can not be used in tokenizer merge"
+        )
+
+    tok_dict = json.loads(tokenizer._tokenizer.to_str())
+    if tok_dict["model"]["type"] != "BPE":
+        raise RuntimeError(
+            f"Tokenizer for {path} has type {tok_dict['model']['type']}, "
+            "but only BPE is currently supported for tokenizer merge"
+        )
+
+    tok_dict["added_tokens"] = [
+        e for e in tok_dict["added_tokens"] if e["id"] < vocab_size
+    ]
+
+    for tok in unused_toks:
+        if tok in tok_dict["model"]["vocab"]:
+            del tok_dict["model"]["vocab"][tok]
+
+    def _keep_merge(m):
+        toks = m.split(" ")
+        for tok in toks:
+            if tok in unused_toks:
+                return False
+        return True
+
+    tok_dict["model"]["merges"] = [
+        e for e in tok_dict["model"]["merges"] if _keep_merge(e)
+    ]
+    tokenizer._tokenizer = tokenizers.Tokenizer.from_str(json.dumps(tok_dict))
+    return tokenizer
+
+
+def build_union_tokenizer(
+    base_tok: transformers.PreTrainedTokenizerBase,
+    tokenizers: Dict[ModelReference, transformers.PreTrainedTokenizerBase],
+) -> transformers.PreTrainedTokenizerBase:
+    out_added_tokens = {}
+    out_vocab = {}
+
+    for model, tokenizer in tokenizers.items():
+        vocab_size = get_vocab_size(model) or tokenizer.vocab_size
+        added_tokens = tokenizer.added_tokens_decoder
+
+        vocab = tokenizer.get_vocab()
+        for tok, idx in vocab.items():
+            if idx >= vocab_size:
+                logging.warning(
+                    f"Token {repr(tok)} present in {model.path} tokenizer but >= vocab_size"
+                )
+                continue
+            if tok in added_tokens:
+                # deal with later
+                continue
+
+            if tok not in out_vocab:
+                out_vocab[tok] = len(out_vocab)
+
+        for tok, info in tokenizer.added_tokens_decoder.items():
+            if tok in out_added_tokens:
+                if out_added_tokens[tok] != info:
+                    logging.warning(
+                        f"Token '{tok}' added with multiple different settings, using first"
+                    )
+                continue
+            out_added_tokens[tok] = info
+
+    res = base_tok
+    orig_base_vocab = base_tok.get_vocab()
+    for tok in out_vocab:
+        if tok in out_added_tokens:
+            continue
+
+        if tok not in orig_base_vocab:
+            res.add_tokens(tok)
+
+    for info in out_added_tokens.values():
+        res.add_tokens(info)
+    return res
+
+
 def build_tokenizer(
     config: MergeConfiguration,
     trust_remote_code: bool,
@@ -33,19 +133,19 @@ def build_tokenizer(
     if base_model is None:
         raise RuntimeError("No models referenced")
 
-    tokenizer_out = transformers.AutoTokenizer.from_pretrained(
+    tokenizer_out = get_stripped_tokenizer(
         base_model.path, trust_remote_code=trust_remote_code
     )
 
     # load all tokenizers
     logging.info("Loading tokenizers")
-    vocabularies = {base_model: tokenizer_out.get_vocab()}
+    tokenizers = {base_model: tokenizer_out}
     for model in config.referenced_models():
         if model == base_model:
             continue
 
         try:
-            model_tok = transformers.AutoTokenizer.from_pretrained(
+            model_tok = get_stripped_tokenizer(
                 model.path, trust_remote_code=trust_remote_code
             )
         except Exception:
@@ -53,7 +153,7 @@ def build_tokenizer(
                 f"Unable to load tokenizer for {model}. Assuming same as {base_model}."
             )
             continue
-        vocabularies[model] = model_tok.get_vocab()
+        tokenizers[model] = model_tok
 
     logging.info("Building output tokenizer")
     # build final vocabulary
@@ -61,15 +161,7 @@ def build_tokenizer(
         # it done
         pass
     elif config.tokenizer_source == "union":
-        added = set(tokenizer_out.get_vocab().keys())
-
-        for model_vocab in tqdm.tqdm(vocabularies.values(), total=len(vocabularies)):
-            for tok in tqdm.tqdm(model_vocab, leave=False):
-                if tok not in added:
-                    tokenizer_out.add_tokens(tok)
-                    added.add(tok)
-
-        del added
+        tokenizer_out = build_union_tokenizer(tokenizer_out, tokenizers)
     elif config.tokenizer_source.startswith("model:"):
         tokenizer_out = transformers.AutoTokenizer.from_pretrained(
             config.tokenizer_source.removeprefix("model:"),
@@ -83,10 +175,10 @@ def build_tokenizer(
     logging.info("Building permutations")
     permutations = {}
     for model in tqdm.tqdm(config.referenced_models()):
-        if model in vocabularies:
-            model_vocab = vocabularies[model]
+        if model in tokenizers:
+            model_vocab = tokenizers[model].get_vocab()
         else:
-            model_vocab = vocabularies[base_model]
+            model_vocab = tokenizers[base_model].get_vocab()
 
         vocab_size = get_vocab_size(model, trust_remote_code=trust_remote_code)
         if vocab_size is None:


### PR DESCRIPTION
Addresses some situations where merging models with unused tokens can produce NaN entries in lm_head/embed_tokens.

Also greatly reduces memory usage of tokenizer merging. Materializing the full permutation matrix for a Yi model with 64K tokens was costing ~16gb per model. Just storing an index remapping dictionary reduces this to ~512kb.