### PR TITLE
Add --safe-serialization/--no-safe-serialization

### DIFF
--- a/mergekit/graph.py
+++ b/mergekit/graph.py
@@ -235,7 +235,13 @@ class Executor:
         self.cuda = cuda
         self.low_cpu_memory = low_cpu_memory
 
-    def run(self, out_path: str, max_shard_size: int, clone_tensors: bool = False):
+    def run(
+        self,
+        out_path: str,
+        max_shard_size: int,
+        clone_tensors: bool = False,
+        safe_serialization: bool = True,
+    ):
         """
         Execute the computation graph and save results to disk.
 
@@ -245,8 +251,13 @@ class Executor:
         Args:
             out_path (str): The path to the directory where the computed tensors will be saved.
             max_shard_size (int): The maximum size of each saved shard.
+            safe_serialization (bool): Write the output tensors using safetensors.
         """
-        writer = TensorWriter(out_path, max_shard_size=max_shard_size)
+        writer = TensorWriter(
+            out_path,
+            max_shard_size=max_shard_size,
+            safe_serialization=safe_serialization,
+        )
         for ref, tensor in tqdm.tqdm(self.generate_tensors(), total=len(self.targets)):
             if not self.low_cpu_memory:
                 tensor = tensor.cpu()

--- a/mergekit/merge.py
+++ b/mergekit/merge.py
@@ -44,6 +44,7 @@ class MergeOptions(BaseModel):
     random_seed: Optional[int] = None
     lazy_unpickle: bool = False
     write_model_card: bool = True
+    safe_serialization: bool = True
 
 
 def run_merge(
@@ -111,6 +112,7 @@ def run_merge(
         out_path,
         max_shard_size=options.out_shard_size,
         clone_tensors=options.clone_tensors,
+        safe_serialization=options.safe_serialization,
     )
 
     cfg_out = method.model_out_config(

--- a/mergekit/options.py
+++ b/mergekit/options.py
@@ -35,6 +35,7 @@ OPTION_HELP = {
     "random_seed": "Seed for reproducible use of randomized merge methods",
     "lazy_unpickle": "Experimental lazy unpickler for lower memory usage",
     "write_model_card": "Output README.md containing details of the merge",
+    "safe_serialization": "Save output in safetensors. Do this, don't poison the world with more pickled models.",
 }
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,11 +13,15 @@ def run_and_check_merge(
     config: MergeConfiguration,
     check_nan: bool = True,
     validate: Optional[Callable[[str], None]] = None,
+    index_json_name: Optional[str] = None,
 ):
+    if index_json_name is None:
+        index_json_name = "model.safetensors.index.json"
+
     with tempfile.TemporaryDirectory() as tmpdir:
         run_merge(config, out_path=tmpdir, options=MergeOptions())
         assert os.path.exists(
-            os.path.join(tmpdir, "model.safetensors.index.json")
+            os.path.join(tmpdir, index_json_name)
         ), "No index file for merge"
         assert os.path.exists(
             os.path.join(tmpdir, "config.json")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+
+import torch
+
+from mergekit.io import TensorWriter
+
+
+class TestTensorWriter:
+    def test_safetensors(self):
+        with tempfile.TemporaryDirectory() as d:
+            writer = TensorWriter(d, safe_serialization=True)
+            writer.save_tensor("steve", torch.randn(4))
+            writer.finalize()
+
+            assert os.path.exists(os.path.join(d, "model-00001-of-00001.safetensors"))
+            assert os.path.exists(os.path.join(d, "model.safetensors.index.json"))
+
+    def test_pickle(self):
+        with tempfile.TemporaryDirectory() as d:
+            writer = TensorWriter(d, safe_serialization=False)
+            writer.save_tensor("timothan", torch.randn(4))
+            writer.finalize()
+
+            assert os.path.exists(os.path.join(d, "pytorch_model-00001-of-00001.bin"))
+            assert os.path.exists(os.path.join(d, "pytorch_model.bin.index.json"))


### PR DESCRIPTION
Addresses #90. But really do stick with safetensors wherever possible - they're faster, have native lazy loading support, don't introduce arbitrary code execution vulnerabilities, and are overall just nicer.