### PR TITLE
Handle new Phi-2 tensor names

### DIFF
--- a/mergekit/architecture.py
+++ b/mergekit/architecture.py
@@ -310,6 +310,37 @@ PHI2_INFO = StaticTensorNames(
         "mlp.fc2.bias",
         "mlp.fc2.weight",
     ],
+    num_layers_key="n_layer",
+)
+
+
+PHI2_INFO_AGAIN_BUT_DIFFERENT = StaticTensorNames(
+    name="PhiForCausalLM",
+    pre_weight_names=["model.embed_tokens.weight"],
+    post_weight_names=[
+        "lm_head.bias",
+        "lm_head.weight",
+        "model.final_layernorm.bias",
+        "model.final_layernorm.weight",
+    ],
+    embed_weight_names=["lm_head.weight", "model.embed_tokens.weight"],
+    layer_prefix_format="model.layers.{idx}",
+    layer_weight_suffixes=[
+        "input_layernorm.bias",
+        "input_layernorm.weight",
+        "self_attn.dense.bias",
+        "self_attn.dense.weight",
+        "self_attn.q_proj.bias",
+        "self_attn.q_proj.weight",
+        "self_attn.k_proj.bias",
+        "self_attn.k_proj.weight",
+        "self_attn.v_proj.bias",
+        "self_attn.v_proj.weight",
+        "mlp.fc1.bias",
+        "mlp.fc1.weight",
+        "mlp.fc2.bias",
+        "mlp.fc2.weight",
+    ],
 )
 
 
@@ -321,6 +352,12 @@ def get_architecture_info(config: PretrainedConfig) -> StaticTensorNames:
     if arch_name == PhiTensorNames.architecture_name:
         return PhiTensorNames(config)
 
+    if arch_name == PHI2_INFO.name:
+        if config.model_type == "phi-msft":
+            return PHI2_INFO
+        elif config.model_type == "phi":
+            return PHI2_INFO_AGAIN_BUT_DIFFERENT
+
     supported = [
         LLAMA_INFO,
         MISTRAL_INFO,
@@ -330,7 +367,6 @@ def get_architecture_info(config: PretrainedConfig) -> StaticTensorNames:
         GPT2_SEQCLASS_INFO,
         CHATGLM_INFO,
         STABLELM_INFO,
-        PHI2_INFO,
     ]
     for arch in supported:
         if arch.name == arch_name:


### PR DESCRIPTION
Add support for the new set of tensor names used by Phi 2. Unfortunately does not currently allow original-flavor and new-style to be mixed. I'll revisit this in the near future when I get to refactoring the architecture system.

Thanks to whoever at Microsoft changed the `model_type` field - it's super helpful to have such a clear call-out for the change.