### PR TITLE
Resolve 'tuple' Object Not Callable Error in referenced_models Invocation

### DIFF
--- a/mergekit/tokenizer.py
+++ b/mergekit/tokenizer.py
@@ -176,7 +176,7 @@ def build_tokenizer(
     trust_remote_code: bool,
 ) -> Tuple[transformers.PreTrainedTokenizer, Dict[ModelReference, torch.IntTensor]]:
     if base_model is None:
-        base_model = referenced_models()[0]
+        base_model = referenced_models[0]
     if base_model is None:
         raise RuntimeError("No models referenced")
 


### PR DESCRIPTION
This PR fixes the issue encountered while attempting to extract the base model from the referenced models tuple. However, the current implementation is causing an error because we are trying to call a tuple, which is not possible.

This error was encountered while trying to create a Frankenstein model.